### PR TITLE
Add additional query params to the mock executor

### DIFF
--- a/mock_executor.go
+++ b/mock_executor.go
@@ -49,10 +49,11 @@ type MockExecutor struct {
 	BatchWriteItemCall   *MockExecutorCall
 	BatchWriteItemError  error
 
-	QueryCalled      bool
-	QueryCall        *MockExecutorCall
-	QueryError       error
-	QueryResultItems []Document
+	QueryCalled           bool
+	QueryCall             *MockExecutorCall
+	QueryError            error
+	QueryResultItems      []Document
+	QueryLastEvaluatedKey Document
 
 	UpdateItemCalled bool
 	UpdateItemCall   *MockExecutorCall
@@ -84,7 +85,8 @@ type MockExecutorCall struct {
 	Ascending              bool
 	Limit                  uint
 
-	BatchWrites BatchWriteTableMap
+	BatchWrites       BatchWriteTableMap
+	ExclusiveStartKey Document
 }
 
 func (e *MockExecutor) BatchWriteItem(batchWrite *BatchWrite) (*BatchWriteResult, error) {
@@ -147,9 +149,10 @@ func (e *MockExecutor) Query(query *Query) (*QueryResult, error) {
 		Ascending:                 ascending,
 		ConsistentRead:            consistent,
 		Limit:                     query.req.Limit,
+		ExclusiveStartKey:         query.req.ExclusiveStartKey,
 	})
 
-	return &QueryResult{Items: e.QueryResultItems}, e.QueryError
+	return &QueryResult{Items: e.QueryResultItems, LastEvaluatedKey: e.QueryLastEvaluatedKey}, e.QueryError
 }
 
 func (e *MockExecutor) UpdateItem(update *UpdateItem) (*UpdateItemResult, error) {


### PR DESCRIPTION
This change enables mockist testing against the ExclusiveStartKey
and LastEvaluatedKey parameters.

- Add `QueryLastEvaluatedKey` to `MockExecutor`
- Add `ExclusiveStartKey` to `MockExecutorCall`