### PR TITLE
Add `AsDocumentList` to List

### DIFF
--- a/types.go
+++ b/types.go
@@ -2,6 +2,7 @@ package dynago
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strconv"
 	"time"
@@ -14,6 +15,18 @@ type NumberSet []string
 type BinarySet [][]byte
 
 type List []interface{}
+
+func (l List) AsDocumentList() ([]Document, error) {
+	docs := make([]Document, len(l))
+	for i, listItem := range l {
+		if doc, ok := listItem.(Document); !ok {
+			return docs[:i], fmt.Errorf("item at index %d was not a Document", i)
+		} else {
+			docs[i] = doc
+		}
+	}
+	return docs, nil
+}
 
 type Number string
 

--- a/types_test.go
+++ b/types_test.go
@@ -57,6 +57,24 @@ func TestNumberFloatValReturnsAnErrorIfItCannotParseTheValue(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestListAsDocumentListReturnsAListOfDocuments(t *testing.T) {
+	list := dynago.List{dynago.Document{"id": 1}}
+	docList, _ := list.AsDocumentList()
+	assert.Equal(t, dynago.Document{"id": 1}, docList[0])
+}
+
+func TestListAsDocumentListReturnsAnErrorIfThereAreNonDocuments(t *testing.T) {
+	list := dynago.List{dynago.Document{"real": "item"}, "imnotadocument"}
+	_, err := list.AsDocumentList()
+	assert.Equal(t, err.Error(), "item at index 1 was not a Document")
+}
+
+func TestListAsDocumentListReturnsTheDocumentsUpToTheFirstNonDocument(t *testing.T) {
+	list := dynago.List{dynago.Document{"real": "item"}, "imnotadocument", dynago.Document{"i won't": "show up"}}
+	docList, _ := list.AsDocumentList()
+	assert.Equal(t, []dynago.Document{dynago.Document{"real": "item"}}, docList)
+}
+
 func TestDocumentGetStringReturnsTheUnderlyingValueAsAString(t *testing.T) {
 	doc := dynago.Document{"name": "Timmy Testerson"}
 	assert.Equal(t, "Timmy Testerson", doc.GetString("name"))


### PR DESCRIPTION
- Return an error if any of the items are not actually documents
- Only return documents up to the first non-document