### PR TITLE
add check on URL for trailing slash

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -38,7 +38,15 @@ type AwsRequester interface {
 }
 
 // Create an AWS executor with a specified endpoint and AWS parameters.
+//
+// NOTE: AWS requires that the endpoint ends in a '/'. If the slash is missing, Dynago
+// will append a '/' to your endpoint URL. This is to prevent a signature error from
+// occuring which will cause authentication to fail.
 func NewAwsExecutor(endpoint, region, accessKey, secretKey string) *AwsExecutor {
+	if len(endpoint) > 0 && endpoint[len(endpoint)-1] != '/' {
+		endpoint = endpoint + "/"
+	}
+
 	signer := aws.AwsSigner{
 		Region:    region,
 		AccessKey: accessKey,

--- a/functional_test.go
+++ b/functional_test.go
@@ -1,9 +1,10 @@
 package dynago_test
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gopkg.in/underarmour/dynago.v1"
 	"gopkg.in/underarmour/dynago.v1/schema"


### PR DESCRIPTION
In an effort to prevent others from encountering my confusing situation I think it would be a good move to either validate the URL as done in this PR or at least do a check on the last character of the URL and log a warning.