### PR TITLE
set default DebugFunc and add README tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ client.PutItem("person", doc).Execute()
 [dynagoNumber]: http://godoc.org/gopkg.in/underarmour/dynago.v1#Number
 [dynagoStringSet]: http://godoc.org/gopkg.in/underarmour/dynago.v1#StringSet
 
+Debugging
+---------
+
+Dynago can dump request or response information for you for use in debugging.
+Simply set `dynago.Debug` with the necessary flags:
+
+```go
+dynago.Debug = dynago.DebugRequests | dynago.DebugResponses
+```
+
+If you would like to change how the debugging is printed, please set `dynago.Debug` (`func(string, ...interface{})`) to your preference.
+
+
 Additional resources
 --------------------
  * [DynamoDB's own API reference][apireference] explains the operations that DynamoDB supports, and as such will provide more information on how specific parameters and values within dynago actually work.
@@ -88,3 +101,5 @@ The past, and the future
 Dynago came out of a dissatisfaction with the existing features of the major implementation of DynamoDB for Go that existed back in April 2015, because many operations used deprecated API's (at the time) and made it very difficult to know which operations we should actually use. Not to mention, the annoying parts of dealing with DynamoDB types.
 
 [AWS-SDK-Go](https://github.com/aws/aws-sdk-go) exists as of June 2015 and has a very up to date API, but it also comes with the pain of using bare structs which minimally wrap protocol-level details of DynamoDB, which makes it a pain to use for writing applications (dealing with DynamoDB's internal type system is boilerplatey). For this reason, there's still a reason for Dynago to exist, but once Amazon has trued up their SDK and brought it out of developer preview, the plan is to have Dynago use it as the underlying protocol and signature implementation, but keep providing dynago's clean and simple API for building queries and marshaling datatypes in dynamodb.
+
+

--- a/helpers.go
+++ b/helpers.go
@@ -1,6 +1,7 @@
 package dynago
 
 import (
+	"log"
 	"strings"
 )
 
@@ -73,7 +74,9 @@ This is a set of bit-flags you can use to set up how much debugging dynago uses:
 var Debug DebugFlags
 
 // Set the target of debug. Must be set for debug to be used.
-var DebugFunc func(format string, v ...interface{})
+var DebugFunc func(format string, v ...interface{}) = func(format string, v ...interface{}) {
+	log.Printf("DEBUG:\n"+format, v...)
+}
 
 // Convenience method to check if a value has a flag:
 //    Debug.HasFlags(DebugRequests)


### PR DESCRIPTION
As a new user it was confusing to use the debug facilities. This adds a section to the README and sets a default option for `DebugFunc` (the stack trace from not setting it wasn't obvious).