### PR TITLE
fixed call to create new aws client

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Example
 Run a query:
 
 ```go
-client := dynago.NewClient(endpoint, accessKey, secretKey)
+client := dynago.NewAwsClient(endpoint, accessKey, secretKey)
 
 query := client.Query(table).
 	KeyConditionExpression("UserId = :uid", dynago.Param{":uid", 42}).


### PR DESCRIPTION
Corrected typo in README , it should be `NewAwsClient` instead of `NewClient`.