### PR TITLE
Add NewAwsClientFromEnv, to run on AWS Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Run a query:
 
 ```go
 client := dynago.NewAwsClient(region, accessKey, secretKey)
+// or you can use below if you have AWS credential values in ENV,
+// in case of running on AWS Lambda, etc.
+// client := dynago.NewAwsClientFromEnv()
 
 query := client.Query(table).
 	KeyConditionExpression("UserId = :uid", dynago.P(":uid", 42)).

--- a/client.go
+++ b/client.go
@@ -13,7 +13,7 @@ secretKey is your amazon secret key ID.
 */
 func NewAwsClient(region string, accessKey string, secretKey string) *Client {
 	endpoint := "https://dynamodb." + region + ".amazonaws.com/"
-	return NewClient(NewAwsExecutor(endpoint, region, accessKey, secretKey))
+	return NewClient(NewAwsExecutor(endpoint, region, accessKey, secretKey, ""))
 }
 
 /*

--- a/client_env.go
+++ b/client_env.go
@@ -1,0 +1,44 @@
+package dynago
+
+import (
+	"errors"
+	"os"
+)
+
+/*
+NewAwsClientFromEnv is a shortcut to create a new dynamo client set up for AWS executor.
+It retrieves credentials from the environment variables of the running process.
+
+Environment variables used:
+
+* Access Key ID:     AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY
+* Secret Access Key: AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY
+* Region:            AWS_REGION
+* Security Token:    AWS_SESSION_TOKEN (optional)
+*/
+func NewAwsClientFromEnv() (*Client, error) {
+	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+	if accessKey == "" {
+		accessKey = os.Getenv("AWS_ACCESS_KEY")
+		if accessKey == "" {
+			return nil, errors.New("AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY not found in environment")
+		}
+	}
+
+	secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	if secretKey == "" {
+		secretKey = os.Getenv("AWS_SECRET_KEY")
+		if secretKey == "" {
+			return nil, errors.New("AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY not found in environment")
+		}
+	}
+
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		return nil, errors.New("AWS_REGION not found in environment")
+	}
+
+	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
+	endpoint := "https://dynamodb." + region + ".amazonaws.com/"
+	return NewClient(NewAwsExecutor(endpoint, region, accessKey, secretKey, sessionToken)), nil
+}

--- a/executor.go
+++ b/executor.go
@@ -41,12 +41,13 @@ type AwsRequester interface {
 }
 
 // Create an AWS executor with a specified endpoint and AWS parameters.
-func NewAwsExecutor(endpoint, region, accessKey, secretKey string) *AwsExecutor {
+func NewAwsExecutor(endpoint, region, accessKey, secretKey, sessionToken string) *AwsExecutor {
 	signer := aws.AwsSigner{
-		Region:    region,
-		AccessKey: accessKey,
-		SecretKey: secretKey,
-		Service:   "dynamodb",
+		Region:       region,
+		AccessKey:    accessKey,
+		SecretKey:    secretKey,
+		SessionToken: sessionToken,
+		Service:      "dynamodb",
 	}
 	requester := &aws.RequestMaker{
 		Endpoint:       aws.FixEndpointUrl(endpoint),

--- a/functional_test.go
+++ b/functional_test.go
@@ -39,7 +39,7 @@ func (f *functional) setUp(t *testing.T) (*assert.Assertions, *dynago.Client) {
 		// Add some posts
 		writer := f.client.BatchWrite()
 		for i := 100; i < 118; i++ {
-			writer = writer.Put("Posts", dynago.Document{"UserId": 42, "Dated": i})
+			writer = writer.Put("Posts", dynago.Document{"UserId": 42, "Dated": i, "NonPrimary": i})
 		}
 		_, err := writer.Execute()
 		assert.NoError(t, err)
@@ -319,17 +319,17 @@ func TestQueryPagination(t *testing.T) {
 	// Paginate the posts
 	q := client.Query("Posts").
 		KeyConditionExpression("UserId = :uid", dynago.P(":uid", 42)).
-		FilterExpression("Dated <> :d", dynago.P(":d", 101)).
+		FilterExpression("NonPrimary <> :d", dynago.P(":d", 101)).
 		Limit(10)
 	results, err := q.Execute()
 	assert.NoError(err)
-	assert.Equal(9, len(results.Items))
+	assert.Equal(10, len(results.Items))
 	assert.Equal(dynago.Number("42"), results.Items[0]["UserId"])
 	assert.Equal(dynago.Number("100"), results.Items[0]["Dated"])
 
 	// Check that we skipped something.
 	assert.Equal(10, results.ScannedCount)
-	assert.Equal(9, results.Count)
+	assert.Equal(10, results.Count)
 
 	assert.NotNil(results.LastEvaluatedKey)
 	assert.Equal(2, len(results.LastEvaluatedKey))

--- a/functional_test.go
+++ b/functional_test.go
@@ -32,7 +32,7 @@ func (f *functional) setUp(t *testing.T) (*assert.Assertions, *dynago.Client) {
 		if endpoint == "" {
 			t.SkipNow()
 		}
-		executor := dynago.NewAwsExecutor(endpoint, ge("REGION", "us-east-1"), ge("ACCESS_KEY", "AKIAEXAMPLE"), ge("SECRET_KEY", "SECRETEXAMPLE"))
+		executor := dynago.NewAwsExecutor(endpoint, ge("REGION", "us-east-1"), ge("ACCESS_KEY", "AKIAEXAMPLE"), ge("SECRET_KEY", "SECRETEXAMPLE"), "")
 		f.client = dynago.NewClient(executor)
 		makeTables(t, f.client)
 


### PR DESCRIPTION
To run on AWS Lambda, we need to add `X-Amz-Security-Token`
to HTTP request header, the value can be retrieved from the
process environment variables.

Since other credential values and region value are also in
the ENV, the new func would be convenient.

Note: as like on Lambda and maybe in some other situation 
we need `X-Amz-Security-Token`, however I did not touch
the original `NewAwsClient`'s args because it must be a 
bigger breaking change.
While the build func should have more requirement, like to
support AWS Cognito credentials, I think a drastic redesign
(to have more flexibility) would be more appreciated.